### PR TITLE
Custom validation messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: ruby
 rvm:
+  - 1.9.3
   - 2.2.3

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Joaquim Adráz
+Copyright (c) 2016 Joaquim Adráz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -217,6 +217,29 @@ Method  | Behaviour
 `#valid?` | `true` or `false`
 `#raise?` | raises a `Compel::InvalidObjectError` if invalid, otherwise returns `#value`
 
+#### Custom Options
+
+**Custom error message**:
+
+*Example 1:*
+```ruby
+schema = Compel.string.required(message: 'this is really required')
+
+result = schema.validate(nil)
+
+p result.errors
+=> ["this is really required"]
+```
+*Example 2:*
+```ruby
+schema = Compel.string.is('Hello', message: 'give me an Hello!')
+
+result = schema.validate(nil)
+
+p result.errors
+=> ["give me an Hello!"]
+```
+
 ==========================
 
 ### Sinatra Integration

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Compel
 
 Ruby Object Coercion and Validation
 
-This is a straight forward way to validate any Ruby object: just give an object and the schema.
+This is a straight forward way to validate any Ruby object: just gmeive an object and the schema.
 
 The motivation was to create an integration for [RestMyCase](https://github.com/goncalvesjoao/rest_my_case) to have validations before any business logic execution and to build a easy way coerce and validate params on [Sinatra](https://github.com/sinatra/sinatra).
 
@@ -219,9 +219,9 @@ Method  | Behaviour
 
 #### Custom Options
 
-**Custom error message**:
+`Custom error message`
 
-*Example 1:*
+Examples:
 ```ruby
 schema = Compel.string.required(message: 'this is really required')
 
@@ -229,9 +229,7 @@ result = schema.validate(nil)
 
 p result.errors
 => ["this is really required"]
-```
-*Example 2:*
-```ruby
+
 schema = Compel.string.is('Hello', message: 'give me an Hello!')
 
 result = schema.validate(nil)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Compel
 
 Ruby Object Coercion and Validation
 
-This is a straight forward way to validate any Ruby object: just gmeive an object and the schema.
+This is a straight forward way to validate any Ruby object: just give an object and the schema.
 
 The motivation was to create an integration for [RestMyCase](https://github.com/goncalvesjoao/rest_my_case) to have validations before any business logic execution and to build a easy way coerce and validate params on [Sinatra](https://github.com/sinatra/sinatra).
 

--- a/lib/compel.rb
+++ b/lib/compel.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'time'
 
 require 'compel/exceptions/type_error'

--- a/lib/compel.rb
+++ b/lib/compel.rb
@@ -1,3 +1,4 @@
+require 'pry'
 require 'time'
 
 require 'compel/exceptions/type_error'

--- a/lib/compel/builder/array.rb
+++ b/lib/compel/builder/array.rb
@@ -13,14 +13,10 @@ module Compel
         end
 
         build_option :items, schema
-
-        self
       end
 
       def is(value)
         build_option :is, Coercion.coerce!(value, Coercion::Array)
-
-        self
       end
 
     end

--- a/lib/compel/builder/array.rb
+++ b/lib/compel/builder/array.rb
@@ -7,12 +7,12 @@ module Compel
         super(Coercion::Array)
       end
 
-      def items(schema)
+      def items(schema, options = {})
         if !schema.is_a?(Schema)
           raise Compel::TypeError, '#items must be a valid Schema'
         end
 
-        build_option :items, schema
+        build_option :items, schema, options
       end
 
       def is(value)

--- a/lib/compel/builder/array.rb
+++ b/lib/compel/builder/array.rb
@@ -12,12 +12,14 @@ module Compel
           raise Compel::TypeError, '#items must be a valid Schema'
         end
 
-        options[:items] = schema
+        build_option :items, schema
+
         self
       end
 
       def is(value)
-        options[:is] = Coercion.coerce!(value, Coercion::Array)
+        build_option :is, Coercion.coerce!(value, Coercion::Array)
+
         self
       end
 

--- a/lib/compel/builder/boolean.rb
+++ b/lib/compel/builder/boolean.rb
@@ -9,7 +9,8 @@ module Compel
 
       def is(value)
         Coercion.coerce!(value, Coercion::Boolean)
-        options[:is] = value
+
+        build_option :is, value
 
         self
       end

--- a/lib/compel/builder/boolean.rb
+++ b/lib/compel/builder/boolean.rb
@@ -11,8 +11,6 @@ module Compel
         Coercion.coerce!(value, Coercion::Boolean)
 
         build_option :is, value
-
-        self
       end
 
     end

--- a/lib/compel/builder/boolean.rb
+++ b/lib/compel/builder/boolean.rb
@@ -7,10 +7,10 @@ module Compel
         super(Coercion::Boolean)
       end
 
-      def is(value)
+      def is(value, options = {})
         Coercion.coerce!(value, Coercion::Boolean)
 
-        build_option :is, value
+        build_option :is, value, options
       end
 
     end

--- a/lib/compel/builder/common.rb
+++ b/lib/compel/builder/common.rb
@@ -4,32 +4,38 @@ module Compel
     module Common
 
       def is(value)
-        options[:is] = Coercion.coerce!(value, self.type)
+        build_option :is, Coercion.coerce!(value, self.type)
+
         self
       end
 
       def required
-        options[:required] = true
+        build_option :required, true
+
         self
       end
 
       def default(value)
-        options[:default] = Coercion.coerce!(value, self.type)
+        build_option :default, Coercion.coerce!(value, self.type)
+
         self
       end
 
       def length(value)
-        options[:length] = Coercion.coerce!(value, Coercion::Integer)
+        build_option :length, Coercion.coerce!(value, Coercion::Integer)
+
         self
       end
 
       def min_length(value)
-        options[:min_length] = Coercion.coerce!(value, Coercion::Integer)
+        build_option :min_length, Coercion.coerce!(value, Coercion::Integer)
+
         self
       end
 
       def max_length(value)
-        options[:max_length] = Coercion.coerce!(value, Coercion::Integer)
+        build_option :max_length, Coercion.coerce!(value, Coercion::Integer)
+
         self
       end
 

--- a/lib/compel/builder/common.rb
+++ b/lib/compel/builder/common.rb
@@ -4,10 +4,10 @@ module Compel
     module Common
 
       def is(value, options = {})
-        build_option :is, Coercion.coerce!(value, self.type)
+        build_option :is, Coercion.coerce!(value, self.type), options
       end
 
-      def required
+      def required(options = {})
         build_option :required, true, options
       end
 

--- a/lib/compel/builder/common.rb
+++ b/lib/compel/builder/common.rb
@@ -5,38 +5,26 @@ module Compel
 
       def is(value)
         build_option :is, Coercion.coerce!(value, self.type)
-
-        self
       end
 
       def required
         build_option :required, true
-
-        self
       end
 
       def default(value)
         build_option :default, Coercion.coerce!(value, self.type)
-
-        self
       end
 
       def length(value)
         build_option :length, Coercion.coerce!(value, Coercion::Integer)
-
-        self
       end
 
       def min_length(value)
         build_option :min_length, Coercion.coerce!(value, Coercion::Integer)
-
-        self
       end
 
       def max_length(value)
         build_option :max_length, Coercion.coerce!(value, Coercion::Integer)
-
-        self
       end
 
     end

--- a/lib/compel/builder/common.rb
+++ b/lib/compel/builder/common.rb
@@ -3,28 +3,28 @@ module Compel
 
     module Common
 
-      def is(value)
+      def is(value, options = {})
         build_option :is, Coercion.coerce!(value, self.type)
       end
 
       def required
-        build_option :required, true
+        build_option :required, true, options
       end
 
-      def default(value)
-        build_option :default, Coercion.coerce!(value, self.type)
+      def default(value, options = {})
+        build_option :default, Coercion.coerce!(value, self.type), options
       end
 
-      def length(value)
-        build_option :length, Coercion.coerce!(value, Coercion::Integer)
+      def length(value, options = {})
+        build_option :length, Coercion.coerce!(value, Coercion::Integer), options
       end
 
-      def min_length(value)
-        build_option :min_length, Coercion.coerce!(value, Coercion::Integer)
+      def min_length(value, options = {})
+        build_option :min_length, Coercion.coerce!(value, Coercion::Integer), options
       end
 
-      def max_length(value)
-        build_option :max_length, Coercion.coerce!(value, Coercion::Integer)
+      def max_length(value, options = {})
+        build_option :max_length, Coercion.coerce!(value, Coercion::Integer), options
       end
 
     end

--- a/lib/compel/builder/common_value.rb
+++ b/lib/compel/builder/common_value.rb
@@ -4,22 +4,26 @@ module Compel
     module CommonValue
 
       def in(value)
-        options[:in] = coerce_values_ary!(value, :in)
+        build_option :in, coerce_values_ary!(value, :in)
+
         self
       end
 
       def range(value)
-        options[:range] = coerce_values_ary!(value, :range)
+        build_option :range, coerce_values_ary!(value, :range)
+
         self
       end
 
       def min(value)
-        options[:min] = coerce_value!(value, :min)
+        build_option :min, coerce_value!(value, :min)
+
         self
       end
 
       def max(value)
-        options[:max] = coerce_value!(value, :max)
+        build_option :max, coerce_value!(value, :max)
+
         self
       end
 

--- a/lib/compel/builder/common_value.rb
+++ b/lib/compel/builder/common_value.rb
@@ -5,26 +5,18 @@ module Compel
 
       def in(value)
         build_option :in, coerce_values_ary!(value, :in)
-
-        self
       end
 
       def range(value)
         build_option :range, coerce_values_ary!(value, :range)
-
-        self
       end
 
       def min(value)
         build_option :min, coerce_value!(value, :min)
-
-        self
       end
 
       def max(value)
         build_option :max, coerce_value!(value, :max)
-
-        self
       end
 
       def coerce_values_ary!(values, method)

--- a/lib/compel/builder/common_value.rb
+++ b/lib/compel/builder/common_value.rb
@@ -3,20 +3,20 @@ module Compel
 
     module CommonValue
 
-      def in(value)
-        build_option :in, coerce_values_ary!(value, :in)
+      def in(value, options = {})
+        build_option :in, coerce_values_ary!(value, :in), options
       end
 
-      def range(value)
-        build_option :range, coerce_values_ary!(value, :range)
+      def range(value, options = {})
+        build_option :range, coerce_values_ary!(value, :range), options
       end
 
-      def min(value)
-        build_option :min, coerce_value!(value, :min)
+      def min(value, options = {})
+        build_option :min, coerce_value!(value, :min), options
       end
 
-      def max(value)
-        build_option :max, coerce_value!(value, :max)
+      def max(value, options = {})
+        build_option :max, coerce_value!(value, :max), options
       end
 
       def coerce_values_ary!(values, method)

--- a/lib/compel/builder/date.rb
+++ b/lib/compel/builder/date.rb
@@ -11,14 +11,10 @@ module Compel
 
       def format(value)
         build_option :format, value
-
-        self
       end
 
       def iso8601
         build_option :format, '%Y-%m-%d'
-
-        self
       end
 
     end

--- a/lib/compel/builder/date.rb
+++ b/lib/compel/builder/date.rb
@@ -10,12 +10,14 @@ module Compel
       end
 
       def format(value)
-        options[:format] = value
+        build_option :format, value
+
         self
       end
 
       def iso8601
-        options[:format] = '%Y-%m-%d'
+        build_option :format, '%Y-%m-%d'
+
         self
       end
 

--- a/lib/compel/builder/date.rb
+++ b/lib/compel/builder/date.rb
@@ -9,12 +9,12 @@ module Compel
         super(Coercion::Date)
       end
 
-      def format(value)
-        build_option :format, value
+      def format(value, options = {})
+        build_option :format, value, options
       end
 
-      def iso8601
-        build_option :format, '%Y-%m-%d'
+      def iso8601(options = {})
+        build_option :format, '%Y-%m-%d', options
       end
 
     end

--- a/lib/compel/builder/datetime.rb
+++ b/lib/compel/builder/datetime.rb
@@ -11,14 +11,10 @@ module Compel
 
       def format(value)
         build_option :format, value
-
-        self
       end
 
       def iso8601
         build_option :format, '%FT%T'
-
-        self
       end
 
     end

--- a/lib/compel/builder/datetime.rb
+++ b/lib/compel/builder/datetime.rb
@@ -10,12 +10,14 @@ module Compel
       end
 
       def format(value)
-        options[:format] = value
+        build_option :format, value
+
         self
       end
 
       def iso8601
-        options[:format] = '%FT%T'
+        build_option :format, '%FT%T'
+
         self
       end
 

--- a/lib/compel/builder/datetime.rb
+++ b/lib/compel/builder/datetime.rb
@@ -9,12 +9,12 @@ module Compel
         super(Coercion::DateTime)
       end
 
-      def format(value)
-        build_option :format, value
+      def format(value, options = {})
+        build_option :format, value, options
       end
 
-      def iso8601
-        build_option :format, '%FT%T'
+      def iso8601(options = {})
+        build_option :format, '%FT%T', options
       end
 
     end

--- a/lib/compel/builder/hash.rb
+++ b/lib/compel/builder/hash.rb
@@ -6,11 +6,12 @@ module Compel
       def initialize
         super(Coercion::Hash)
 
-        options[:keys] = {}
+        options[:keys] = { value: {} }
       end
 
       def keys(object)
-        options[:keys] = coerce_keys_schemas(object)
+        build_option :keys, coerce_keys_schemas(object)
+
         self
       end
 

--- a/lib/compel/builder/hash.rb
+++ b/lib/compel/builder/hash.rb
@@ -11,8 +11,6 @@ module Compel
 
       def keys(object)
         build_option :keys, coerce_keys_schemas(object)
-
-        self
       end
 
       private

--- a/lib/compel/builder/hash.rb
+++ b/lib/compel/builder/hash.rb
@@ -9,8 +9,8 @@ module Compel
         options[:keys] = { value: {} }
       end
 
-      def keys(object)
-        build_option :keys, coerce_keys_schemas(object)
+      def keys(object, options = {})
+        build_option :keys, coerce_keys_schemas(object), options
       end
 
       private

--- a/lib/compel/builder/schema.rb
+++ b/lib/compel/builder/schema.rb
@@ -8,35 +8,35 @@ module Compel
       attr_reader :type,
                   :options
 
+      def self.human_name
+        "#{self.name.split('::')[1..-1].join('::')}"
+      end
+
       def initialize(type)
         @type = type
         @options = default_options
       end
 
       def required?
-        options[:required]
+        options[:required][:value]
       end
 
       def default_value
-        options[:default]
+        options[:default][:value] if options[:default]
       end
 
       def validate(object)
         Contract.new(object, self).validate
       end
 
-      class << self
+      def build_option(name, value, extra_options = {})
+        options[name] = { value: value }.merge(extra_options)
 
-        def human_name
-          "#{self.name.split('::')[1..-1].join('::')}"
-        end
-
+        self
       end
 
-      protected
-
       def default_options
-        { required: false }
+        { required: { value: false } }
       end
 
     end

--- a/lib/compel/builder/string.rb
+++ b/lib/compel/builder/string.rb
@@ -18,17 +18,20 @@ module Compel
       end
 
       def format(regex)
-        options[:format] = Coercion.coerce!(regex, Coercion::Regexp)
+        build_option :format, Coercion.coerce!(regex, Coercion::Regexp)
+
         self
       end
 
       def url
-        options[:format] = URL_REGEX
+        build_option :format, URL_REGEX
+
         self
       end
 
       def email
-        options[:format] = EMAIL_REGEX
+        build_option :format, EMAIL_REGEX
+
         self
       end
 

--- a/lib/compel/builder/string.rb
+++ b/lib/compel/builder/string.rb
@@ -17,8 +17,8 @@ module Compel
         super(Coercion::String)
       end
 
-      def format(regex)
-        build_option :format, Coercion.coerce!(regex, Coercion::Regexp)
+      def format(regex, options = {})
+        build_option :format, Coercion.coerce!(regex, Coercion::Regexp), options
       end
 
       def url

--- a/lib/compel/builder/string.rb
+++ b/lib/compel/builder/string.rb
@@ -19,20 +19,14 @@ module Compel
 
       def format(regex)
         build_option :format, Coercion.coerce!(regex, Coercion::Regexp)
-
-        self
       end
 
       def url
         build_option :format, URL_REGEX
-
-        self
       end
 
       def email
         build_option :format, EMAIL_REGEX
-
-        self
       end
 
     end

--- a/lib/compel/builder/string.rb
+++ b/lib/compel/builder/string.rb
@@ -21,12 +21,12 @@ module Compel
         build_option :format, Coercion.coerce!(regex, Coercion::Regexp), options
       end
 
-      def url
-        build_option :format, URL_REGEX
+      def url(options = {})
+        build_option :format, URL_REGEX, options
       end
 
-      def email
-        build_option :format, EMAIL_REGEX
+      def email(options = {})
+        build_option :format, EMAIL_REGEX, options
       end
 
     end

--- a/lib/compel/builder/time.rb
+++ b/lib/compel/builder/time.rb
@@ -9,12 +9,12 @@ module Compel
         super(Coercion::Time)
       end
 
-      def format(value)
-        build_option :format, value
+      def format(value, options = {})
+        build_option :format, value, options
       end
 
-      def iso8601
-        build_option :format, '%FT%T'
+      def iso8601(options = {})
+        build_option :format, '%FT%T', options
       end
 
     end

--- a/lib/compel/builder/time.rb
+++ b/lib/compel/builder/time.rb
@@ -11,14 +11,10 @@ module Compel
 
       def format(value)
         build_option :format, value
-
-        self
       end
 
       def iso8601
         build_option :format, '%FT%T'
-
-        self
       end
 
     end

--- a/lib/compel/builder/time.rb
+++ b/lib/compel/builder/time.rb
@@ -10,12 +10,14 @@ module Compel
       end
 
       def format(value)
-        options[:format] = value
+        build_option :format, value
+
         self
       end
 
       def iso8601
-        options[:format] = '%FT%T'
+        build_option :format, '%FT%T'
+
         self
       end
 

--- a/lib/compel/coercion/types/date.rb
+++ b/lib/compel/coercion/types/date.rb
@@ -8,7 +8,7 @@ module Compel
       end
 
       def default_format
-         '%Y-%m-%d'
+        '%Y-%m-%d'
       end
 
     end

--- a/lib/compel/coercion/types/date_type.rb
+++ b/lib/compel/coercion/types/date_type.rb
@@ -6,7 +6,11 @@ module Compel
       attr_reader :format
 
       def coerce_value
-        @format = options[:format] || default_format
+        @format = default_format
+
+        if options[:format]
+          @format = options[:format][:value]
+        end
 
         if value.is_a?(klass)
           @value = value.strftime(format)

--- a/lib/compel/validation/conditions/condition.rb
+++ b/lib/compel/validation/conditions/condition.rb
@@ -15,14 +15,21 @@ module Compel
       def initialize(value, option_value, options = {})
         @value = value
         @value_type = options.delete(:type) || Coercion::Types::Any
+        @options = options
         @option_value = option_value
       end
 
       def validate
-        # result is an error message
-        result = validate_value
+        Validation::Result.new \
+          value, value_type, validate_value_with_error_message
+      end
 
-        Validation::Result.new(value, value_type, result)
+      private
+
+      def validate_value_with_error_message
+        error_message = validate_value
+
+        options[:message] || error_message
       end
 
     end

--- a/lib/compel/validation/validation.rb
+++ b/lib/compel/validation/validation.rb
@@ -27,16 +27,21 @@ module Compel
     }
 
     def validate(value, type, options)
-      if value.nil? && !!options[:required]
+      if value.nil? && !!(options[:required] && options[:required][:value])
         return ['is required']
       end
 
       errors = Errors.new
 
-      options.each do |option, option_value|
-        next unless condition_exists?(option)
+      options.each do |name, option_values|
+        next unless condition_exists?(name)
 
-        result = condition_klass(option).validate(value, option_value, type: type)
+        cloned_options = option_values.dup
+
+        option_value = cloned_options.delete(:value)
+
+        result = condition_klass(name).validate \
+          value, option_value, cloned_options.merge(type: type)
 
         unless result.valid?
           errors.add :base, result.error_message
@@ -46,12 +51,12 @@ module Compel
       errors.to_hash[:base] || []
     end
 
-    def condition_exists?(option)
-      CONDITIONS.keys.include?(option.to_sym)
+    def condition_exists?(option_name)
+      CONDITIONS.keys.include?(option_name.to_sym)
     end
 
-    def condition_klass(option)
-      CONDITIONS[option.to_sym]
+    def condition_klass(option_name)
+      CONDITIONS[option_name.to_sym]
     end
 
     extend self

--- a/lib/compel/validation/validation.rb
+++ b/lib/compel/validation/validation.rb
@@ -28,7 +28,7 @@ module Compel
 
     def validate(value, type, options)
       if value.nil? && !!(options[:required] && options[:required][:value])
-        return ['is required']
+        return (options[:required][:message] || ['is required'])
       end
 
       errors = Errors.new

--- a/lib/compel/validation/validation.rb
+++ b/lib/compel/validation/validation.rb
@@ -28,7 +28,7 @@ module Compel
 
     def validate(value, type, options)
       if value.nil? && !!(options[:required] && options[:required][:value])
-        return (options[:required][:message] || ['is required'])
+        return [options[:required][:message] || 'is required']
       end
 
       errors = Errors.new

--- a/lib/compel/validators/array_validator.rb
+++ b/lib/compel/validators/array_validator.rb
@@ -10,7 +10,7 @@ module Compel
 
         @errors = Errors.new
         @output = []
-        @items_schema = schema.options[:items]
+        @items_schema = schema.options[:items][:value] if schema.options[:items]
       end
 
       def validate

--- a/lib/compel/validators/hash_validator.rb
+++ b/lib/compel/validators/hash_validator.rb
@@ -12,7 +12,7 @@ module Compel
         super
 
         @errors = Errors.new
-        @keys_schemas = schema.options[:keys]
+        @keys_schemas = schema.options[:keys][:value]
       end
 
       def validate

--- a/spec/compel/builder_spec.rb
+++ b/spec/compel/builder_spec.rb
@@ -383,6 +383,14 @@ describe Compel::Builder do
                 include('is required')
             end
 
+            it 'should have an array for error messages' do
+              schema = Compel.any.required(message: 'this is required')
+              expect(schema.validate(nil).errors.class).to eq Array
+
+              schema = Compel.any.required
+              expect(schema.validate(nil).errors.class).to eq Array
+            end
+
             it 'should use custom error message' do
               schema = Compel.any.required(message: 'this is required')
 

--- a/spec/compel/builder_spec.rb
+++ b/spec/compel/builder_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 describe Compel::Builder do
 
   context 'Schema' do

--- a/spec/compel/builder_spec.rb
+++ b/spec/compel/builder_spec.rb
@@ -22,7 +22,7 @@ describe Compel::Builder do
           it 'should have value' do
             [:in, :range].each do |method|
               builder.send(method, ["#{method}"])
-              expect(builder.options[method]).to eq(["#{method}"])
+              expect(builder.options[method][:value]).to eq(["#{method}"])
             end
           end
 
@@ -35,7 +35,7 @@ describe Compel::Builder do
           it 'should have value' do
             [:min, :max].each do |method|
               builder.send(method, "#{method}")
-              expect(builder.options[method]).to eq("#{method}")
+              expect(builder.options[method][:value]).to eq("#{method}")
             end
           end
 
@@ -53,7 +53,7 @@ describe Compel::Builder do
 
             [:is, :default].each do |method|
               builder.send(method, "#{method}")
-              expect(builder.options[method]).to eq("#{method}")
+              expect(builder.options[method][:value]).to eq("#{method}")
             end
           end
 
@@ -78,7 +78,7 @@ describe Compel::Builder do
           it 'should have value' do
             builder.length(5)
 
-            expect(builder.options[:length]).to be 5
+            expect(builder.options[:length][:value]).to be 5
           end
 
           it 'should raise exception for invalid type' do
@@ -99,13 +99,13 @@ describe Compel::Builder do
           it 'should have value' do
             builder.format('%d-%m-%Y')
 
-            expect(builder.options[:format]).to eq('%d-%m-%Y')
+            expect(builder.options[:format][:value]).to eq('%d-%m-%Y')
           end
 
           it 'should have value' do
             builder.iso8601
 
-            expect(builder.options[:format]).to eq('%Y-%m-%d')
+            expect(builder.options[:format][:value]).to eq('%Y-%m-%d')
           end
 
         end
@@ -115,7 +115,7 @@ describe Compel::Builder do
           it 'should set max value with string and coerce' do
             builder.max('2016-01-01')
 
-            expect(builder.options[:max]).to eq(Date.new(2016, 1, 1))
+            expect(builder.options[:max][:value]).to eq(Date.new(2016, 1, 1))
           end
 
         end
@@ -125,8 +125,8 @@ describe Compel::Builder do
           it 'should set max value with string and coerce' do
             builder.in(['2016-01-01', '2016-01-02'])
 
-            expect(builder.options[:in]).to include(Date.new(2016, 1, 1))
-            expect(builder.options[:in]).to include(Date.new(2016, 1, 2))
+            expect(builder.options[:in][:value]).to include(Date.new(2016, 1, 1))
+            expect(builder.options[:in][:value]).to include(Date.new(2016, 1, 2))
           end
 
         end
@@ -156,7 +156,7 @@ describe Compel::Builder do
             each_date_builder do |builder, klass|
               builder.in([klass.new(2016, 1, 1), klass.new(2016, 1, 2)])
 
-              expect(builder.options[:in].length).to eq 2
+              expect(builder.options[:in][:value].length).to eq 2
             end
           end
 
@@ -174,7 +174,7 @@ describe Compel::Builder do
             each_date_builder do |builder, klass|
               builder.max(klass.new(2016, 1, 1))
 
-              expect(builder.options[:max]).to eq(klass.new(2016, 1, 1))
+              expect(builder.options[:max][:value]).to eq(klass.new(2016, 1, 1))
             end
           end
 
@@ -195,7 +195,7 @@ describe Compel::Builder do
             each_date_builder do |builder, klass|
               builder.min(klass.new(2016, 1, 1))
 
-              expect(builder.options[:min]).to eq(klass.new(2016, 1, 1))
+              expect(builder.options[:min][:value]).to eq(klass.new(2016, 1, 1))
             end
           end
 
@@ -221,7 +221,7 @@ describe Compel::Builder do
           it 'should set in value' do
             builder.in(['a', 'b'])
 
-            expect(builder.options[:in].length).to eq 2
+            expect(builder.options[:in][:value].length).to eq 2
           end
 
           it 'should raise exception for invalid item on array' do
@@ -243,7 +243,7 @@ describe Compel::Builder do
           it 'should have value' do
             builder.format(/1/)
 
-            expect(builder.options[:format]).to eq(/1/)
+            expect(builder.options[:format][:value]).to eq(/1/)
           end
 
         end
@@ -258,7 +258,7 @@ describe Compel::Builder do
           it 'should have value' do
             builder.min_length(4)
 
-            expect(builder.options[:min_length]).to eq(4)
+            expect(builder.options[:min_length][:value]).to eq(4)
           end
 
         end
@@ -273,7 +273,7 @@ describe Compel::Builder do
           it 'should have value' do
             builder.max_length(10)
 
-            expect(builder.options[:max_length]).to eq(10)
+            expect(builder.options[:max_length][:value]).to eq(10)
           end
 
         end
@@ -296,7 +296,7 @@ describe Compel::Builder do
             h: Compel.integer
           })
 
-          keys_schemas = schema.options[:keys]
+          keys_schemas = schema.options[:keys][:value]
 
           expect(keys_schemas[:a].type).to be Compel::Coercion::Float
           expect(keys_schemas[:b].type).to be Compel::Coercion::String
@@ -340,7 +340,7 @@ describe Compel::Builder do
         it 'should have value' do
           builder = Compel.array.items(Compel.integer)
 
-          expect(builder.options[:items].class).to be(Compel::Builder::Integer)
+          expect(builder.options[:items][:value].class).to be(Compel::Builder::Integer)
         end
 
       end
@@ -352,7 +352,7 @@ describe Compel::Builder do
           it 'should build schema' do
             builder = Compel.integer.min(10)
 
-            expect(builder.options[:min]).to eq(10)
+            expect(builder.options[:min][:value]).to eq(10)
           end
 
           it 'should raise exception for invalid value' do

--- a/spec/compel/builder_spec.rb
+++ b/spec/compel/builder_spec.rb
@@ -50,7 +50,6 @@ describe Compel::Builder do
         context '#is, #default' do
 
           it 'should have value' do
-
             [:is, :default].each do |method|
               builder.send(method, "#{method}")
               expect(builder.options[method][:value]).to eq("#{method}")
@@ -382,6 +381,13 @@ describe Compel::Builder do
                 include('is required')
             end
 
+            it 'should use custom error message' do
+              schema = Compel.any.required(message: 'this is required')
+
+              expect(schema.validate(nil).errors).to \
+                include('this is required')
+            end
+
           end
 
           context 'valid' do
@@ -468,6 +474,13 @@ describe Compel::Builder do
                 include('must be [1, 2, 3]')
             end
 
+            it 'should use custom error message' do
+              schema = Compel.any.is(1, message: 'not one')
+
+              expect(schema.validate('two').errors).to \
+                include('not one')
+            end
+
           end
 
           context 'valid' do
@@ -502,6 +515,13 @@ describe Compel::Builder do
                 include('cannot have length different than 1')
             end
 
+            it 'should use custom error message' do
+              schema = Compel.any.length(2, message: 'not the same size')
+
+              expect(schema.validate(12).errors).to \
+                include('not the same size')
+            end
+
           end
 
           context 'valid' do
@@ -520,6 +540,36 @@ describe Compel::Builder do
               result = schema.validate(OpenStruct)
 
               expect(result.valid?).to be true
+            end
+
+          end
+
+        end
+
+        context '#min_length' do
+
+          context 'invalid' do
+
+            it 'should use custom error message' do
+              schema = Compel.any.min_length(2, message: 'min is two')
+
+              expect(schema.validate(1).errors).to \
+                include('min is two')
+            end
+
+          end
+
+        end
+
+        context '#max_length' do
+
+          context 'invalid' do
+
+            it 'should use custom error message' do
+              schema = Compel.any.max_length(2, message: 'max is two')
+
+              expect(schema.validate(123).errors).to \
+                include('max is two')
             end
 
           end
@@ -678,6 +728,12 @@ describe Compel::Builder do
             expect(result.valid?).to be false
           end
 
+          it 'should not validate and use custom error' do
+            result = Compel.string.url(message: 'not an URL').validate('url')
+
+            expect(result.errors).to include('not an URL')
+          end
+
         end
 
         context '#email' do
@@ -698,6 +754,12 @@ describe Compel::Builder do
             result = Compel.string.email.validate('email')
 
             expect(result.valid?).to be false
+          end
+
+          it 'should not validate and use custom error' do
+            result = Compel.string.email(message: 'not an EMAIL').validate('email')
+
+            expect(result.errors).to include('not an EMAIL')
           end
 
         end
@@ -880,6 +942,70 @@ describe Compel::Builder do
           expect(result.valid?).to be false
           expect(result.errors).to \
             include("'1989-0' is not a parsable datetime with format: %FT%T")
+        end
+
+      end
+
+      context 'Integer' do
+
+        context '#in' do
+
+          context 'invalid' do
+
+            it 'should use custom error message' do
+              schema = Compel.integer.in([1, 2], message: 'not in 1 or 2')
+
+              expect(schema.validate(3).errors).to \
+                include('not in 1 or 2')
+            end
+
+          end
+
+        end
+
+        context '#range' do
+
+          context 'invalid' do
+
+            it 'should use custom error message' do
+              schema = Compel.integer.range([1, 2], message: 'not between 1 or 2')
+
+              expect(schema.validate(3).errors).to \
+                include('not between 1 or 2')
+            end
+
+          end
+
+        end
+
+        context '#min' do
+
+          context 'invalid' do
+
+            it 'should use custom error message' do
+              schema = Compel.integer.min(5, message: 'min is five')
+
+              expect(schema.validate(4).errors).to \
+                include('min is five')
+            end
+
+          end
+
+        end
+
+        context '#max' do
+
+          context 'invalid' do
+
+            it 'should use custom error message' do
+              schema = Compel.integer.max(5, message: 'max is five')
+
+              expect(schema.validate(6).errors).to \
+                include('max is five')
+            end
+
+          end
+
         end
 
       end

--- a/spec/compel/coercion_spec.rb
+++ b/spec/compel/coercion_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 describe Compel::Coercion do
 
   context 'Type coercion' do

--- a/spec/compel/coercion_spec.rb
+++ b/spec/compel/coercion_spec.rb
@@ -67,7 +67,8 @@ describe Compel::Coercion do
       end
 
       it 'should coerce with format' do
-        value = Compel::Coercion.coerce!('22-12-2015', Compel::Coercion::Date, { format: '%d-%m-%Y' })
+        value = Compel::Coercion.coerce! \
+          '22-12-2015', Compel::Coercion::Date, { format: { value: '%d-%m-%Y' } }
 
         expect(value).to eq(Date.strptime('22-12-2015', '%d-%m-%Y'))
       end
@@ -98,7 +99,7 @@ describe Compel::Coercion do
       it 'should coerce' do
         [DateTime, Time].each do |time_klass|
           value = Compel::Coercion.coerce! \
-            '2015-12-22', Compel::Coercion.const_get("#{time_klass}"), format: '%Y-%m-%d'
+            '2015-12-22', Compel::Coercion.const_get("#{time_klass}"), format: { value: '%Y-%m-%d' }
 
           expect(value).to be_a time_klass
           expect(value.year).to eq(2015)

--- a/spec/compel/compel_spec.rb
+++ b/spec/compel/compel_spec.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 describe Compel do
 
   context '#run' do

--- a/spec/compel/compel_spec.rb
+++ b/spec/compel/compel_spec.rb
@@ -360,6 +360,14 @@ describe Compel do
           expect(result.errors).to include('must match format ^\\d{4}-\\d{3}$')
         end
 
+        it 'should not compel with custom message' do
+          schema = Compel.string.format(/^\d{4}-\d{3}$/, message: 'this format is not good')
+
+          result = Compel.run('110-100', schema)
+
+          expect(result.errors).to include('this format is not good')
+        end
+
       end
 
     end

--- a/spec/compel/validation_spec.rb
+++ b/spec/compel/validation_spec.rb
@@ -3,13 +3,13 @@ describe Compel::Validation do
   context 'required' do
 
     it 'should validate without errors' do
-      errors = Compel::Validation.validate(123, Compel::Coercion::Integer, { required: true })
+      errors = Compel::Validation.validate(123, Compel::Coercion::Integer, { required: { value: true } })
 
       expect(errors.empty?).to eq(true)
     end
 
     it 'should validate with error' do
-      errors = Compel::Validation.validate(nil,  Compel::Coercion::Integer, { required: true })
+      errors = Compel::Validation.validate(nil,  Compel::Coercion::Integer, { required: { value: true } })
 
       expect(errors.empty?).to eq(false)
       expect(errors).to eq(['is required'])
@@ -20,7 +20,7 @@ describe Compel::Validation do
   context 'length' do
 
     it 'should validate without errors' do
-      errors = Compel::Validation.validate(123,  Compel::Coercion::Integer, { length: 3 })
+      errors = Compel::Validation.validate(123,  Compel::Coercion::Integer, { length: { value: 3 } })
 
       expect(errors.empty?).to eq(true)
     end
@@ -31,7 +31,7 @@ describe Compel::Validation do
 
     def expect_be_in_range(range, value)
       [:in, :range].each do |key|
-        errors = Compel::Validation.validate(value,  Compel::Coercion::String, { key => range })
+        errors = Compel::Validation.validate(value,  Compel::Coercion::String, { key => { value: range } })
         yield errors
       end
     end
@@ -51,13 +51,13 @@ describe Compel::Validation do
     context 'range' do
 
       it 'should validate without errors' do
-        errors = Compel::Validation.validate(2, Compel::Coercion::Integer, range: (1..3))
+        errors = Compel::Validation.validate(2, Compel::Coercion::Integer, range: { value: (1..3) })
 
         expect(errors.empty?).to eq(true)
       end
 
       it 'should validate with errors' do
-        errors = Compel::Validation.validate(4, Compel::Coercion::Integer, range: (1..3))
+        errors = Compel::Validation.validate(4, Compel::Coercion::Integer, range: { value: (1..3) })
 
         expect(errors).to include('must be within 1..3')
       end
@@ -70,14 +70,14 @@ describe Compel::Validation do
 
     it 'should validate with errors' do
       format = /^abcd/
-      errors = Compel::Validation.validate('acb', Compel::Coercion::String, format: format)
+      errors = Compel::Validation.validate('acb', Compel::Coercion::String, format: { value: format })
 
       expect(errors).to include("must match format ^abcd")
     end
 
     it 'should validate without errors' do
       format = /abcd/
-      errors = Compel::Validation.validate('abcd', Compel::Coercion::String, format: format)
+      errors = Compel::Validation.validate('abcd', Compel::Coercion::String, format: { value: format })
       expect(errors.empty?).to eq(true)
     end
 
@@ -86,17 +86,17 @@ describe Compel::Validation do
   context 'is' do
 
     it 'should validate with errors' do
-      errors = Compel::Validation.validate('abcd', Compel::Coercion::Integer, is: 123)
+      errors = Compel::Validation.validate('abcd', Compel::Coercion::Integer, is: { value: 123 })
       expect(errors).to include('must be 123')
     end
 
     it 'should validate with errors 1' do
-      errors = Compel::Validation.validate(nil, Compel::Coercion::Integer, is: 123)
+      errors = Compel::Validation.validate(nil, Compel::Coercion::Integer, is: { value: 123 })
       expect(errors).to include('must be 123')
     end
 
     it 'should validate without errors' do
-      errors = Compel::Validation.validate(123, Compel::Coercion::Integer, is: 123)
+      errors = Compel::Validation.validate(123, Compel::Coercion::Integer, is: { value: 123 })
       expect(errors.empty?).to eq(true)
     end
 
@@ -105,31 +105,31 @@ describe Compel::Validation do
   context 'min' do
 
     it 'should validate without errors for Integer' do
-      errors = Compel::Validation.validate(2, Compel::Coercion::Integer, min: 1)
+      errors = Compel::Validation.validate(2, Compel::Coercion::Integer, min: { value: 1 })
 
       expect(errors.empty?).to be true
     end
 
     it 'should validate without errors for String' do
-      errors = Compel::Validation.validate('b', Compel::Coercion::String, min: 'a')
+      errors = Compel::Validation.validate('b', Compel::Coercion::String, min: { value: 'a' })
 
       expect(errors.empty?).to be true
     end
 
     it 'should validate with errors' do
-      errors = Compel::Validation.validate(1, Compel::Coercion::Integer, min: 3)
+      errors = Compel::Validation.validate(1, Compel::Coercion::Integer, min: { value: 3 })
 
       expect(errors).to include('cannot be less than 3')
     end
 
     it 'should validate with errors for String' do
-      errors = Compel::Validation.validate('a', Compel::Coercion::String, min: 'b')
+      errors = Compel::Validation.validate('a', Compel::Coercion::String, min: { value: 'b' })
 
       expect(errors).to include('cannot be less than b')
     end
 
     it 'should validate with errors for Float' do
-      errors = Compel::Validation.validate(1.54, Compel::Coercion::Float, min: 1.55)
+      errors = Compel::Validation.validate(1.54, Compel::Coercion::Float, min: { value: 1.55 })
 
       expect(errors).to include('cannot be less than 1.55')
     end
@@ -139,37 +139,37 @@ describe Compel::Validation do
   context 'max' do
 
     it 'should validate without errors' do
-      errors = Compel::Validation.validate(5, Compel::Coercion::Integer, min: 5)
+      errors = Compel::Validation.validate(5, Compel::Coercion::Integer, min: { value: 5 })
 
       expect(errors.empty?).to be true
     end
 
     it 'should validate with errors' do
-      errors = Compel::Validation.validate(3, Compel::Coercion::Integer, max: 2)
+      errors = Compel::Validation.validate(3, Compel::Coercion::Integer, max: { value: 2 })
 
       expect(errors).to include('cannot be greater than 2')
     end
 
     it 'should validate without errors for Integer' do
-      errors = Compel::Validation.validate(2, Compel::Coercion::Integer, max: 3)
+      errors = Compel::Validation.validate(2, Compel::Coercion::Integer, max: { value: 3 })
 
       expect(errors.empty?).to be true
     end
 
     it 'should validate without errors for String' do
-      errors = Compel::Validation.validate('b', Compel::Coercion::String, max: 'd')
+      errors = Compel::Validation.validate('b', Compel::Coercion::String, max: { value: 'd' })
 
       expect(errors.empty?).to be true
     end
 
     it 'should validate with errors for String' do
-      errors = Compel::Validation.validate('c', Compel::Coercion::String, max: 'b')
+      errors = Compel::Validation.validate('c', Compel::Coercion::String, max: { value: 'b' })
 
       expect(errors).to include('cannot be greater than b')
     end
 
     it 'should validate with errors for Float' do
-      errors = Compel::Validation.validate(1.56, Compel::Coercion::Float, max: 1.55)
+      errors = Compel::Validation.validate(1.56, Compel::Coercion::Float, max: { value: 1.55 })
 
       expect(errors).to include('cannot be greater than 1.55')
     end
@@ -179,19 +179,19 @@ describe Compel::Validation do
   context 'min_length' do
 
     it 'should validate with errors 1' do
-      errors = Compel::Validation.validate('a', Compel::Coercion::String, min_length: 2)
+      errors = Compel::Validation.validate('a', Compel::Coercion::String, min_length: { value: 2 })
 
       expect(errors).to include('cannot have length less than 2')
     end
 
     it 'should validate without errors' do
-      errors = Compel::Validation.validate('ab', Compel::Coercion::String, min_length: 2)
+      errors = Compel::Validation.validate('ab', Compel::Coercion::String, min_length: { value: 2 })
 
       expect(errors.empty?).to eq(true)
     end
 
     it 'should validate without errors 1' do
-      errors = Compel::Validation.validate(3, Compel::Coercion::Integer, min_length: 2)
+      errors = Compel::Validation.validate(3, Compel::Coercion::Integer, min_length: { value: 2 })
 
       expect(errors).to include('cannot have length less than 2')
     end
@@ -201,19 +201,19 @@ describe Compel::Validation do
   context 'max_length' do
 
     it 'should validate with errors 1' do
-      errors = Compel::Validation.validate('abcdef', Compel::Coercion::String, max_length: 5)
+      errors = Compel::Validation.validate('abcdef', Compel::Coercion::String, max_length: { value: 5 })
 
       expect(errors).to include('cannot have length greater than 5')
     end
 
     it 'should validate without errors' do
-      errors = Compel::Validation.validate('abcde', Compel::Coercion::String, max_length: 5)
+      errors = Compel::Validation.validate('abcde', Compel::Coercion::String, max_length: { value: 5 })
 
       expect(errors.empty?).to eq(true)
     end
 
     it 'should validate without errors 1' do
-      errors = Compel::Validation.validate(1, Compel::Coercion::Integer, max_length: 2)
+      errors = Compel::Validation.validate(1, Compel::Coercion::Integer, max_length: { value: 2 })
 
       expect(errors.empty?).to eq(true)
     end

--- a/spec/compel/validation_spec.rb
+++ b/spec/compel/validation_spec.rb
@@ -9,7 +9,7 @@ describe Compel::Validation do
     end
 
     it 'should validate with error' do
-      errors = Compel::Validation.validate(nil,  Compel::Coercion::Integer, { required: { value: true } })
+      errors = Compel::Validation.validate(nil, Compel::Coercion::Integer, { required: { value: true } })
 
       expect(errors.empty?).to eq(false)
       expect(errors).to eq(['is required'])
@@ -20,7 +20,7 @@ describe Compel::Validation do
   context 'length' do
 
     it 'should validate without errors' do
-      errors = Compel::Validation.validate(123,  Compel::Coercion::Integer, { length: { value: 3 } })
+      errors = Compel::Validation.validate(123, Compel::Coercion::Integer, { length: { value: 3 } })
 
       expect(errors.empty?).to eq(true)
     end
@@ -31,7 +31,7 @@ describe Compel::Validation do
 
     def expect_be_in_range(range, value)
       [:in, :range].each do |key|
-        errors = Compel::Validation.validate(value,  Compel::Coercion::String, { key => { value: range } })
+        errors = Compel::Validation.validate(value, Compel::Coercion::String, { key => { value: range } })
         yield errors
       end
     end


### PR DESCRIPTION
- resolved #8 
- change internals to allow options to all major schema api, only `message` allowed right now
- custom message validation: 
```ruby
schema = Compel.string.required(message: 'this is really required')

result = schema.validate(nil)

p result.errors
=> ["this is really required"]
```