### PR TITLE
Custom validations

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Methods `length`, `min_length` and `max_length` turn the object to validate into
 - `length(``integer``)`
 - `min_length(``integer``)`
 - `max_length(``integer``)`
+- `if`
+  - `if(->(value){ value == 1 })`
+  - `if{|value| value == 1 }`
+  - `if{:custom_validation} # Check the specs for now, I'm rewriting the docs ;)` 
 
 ==========================
 
@@ -291,7 +295,7 @@ end
 
 Add this line to your application's Gemfile:
 
-    gem 'compel', '~> 0.3.7'
+    gem 'compel', '~> 0.4.3'
 
 And then execute:
 

--- a/lib/compel/builder/any.rb
+++ b/lib/compel/builder/any.rb
@@ -7,22 +7,6 @@ module Compel
         super(Coercion::Any)
       end
 
-      def if(lambda = nil, &block)
-        value = \
-          if lambda && lambda.is_a?(Proc) && lambda.arity == 1
-            lambda
-          elsif block && block.arity == 0 && (block.call.is_a?(::Symbol) || block.call.is_a?(::String))
-            block
-          else
-            fail
-          end
-
-        build_option :if, value, options
-
-        rescue
-          raise Compel::TypeError, 'invalid proc for if'
-      end
-
     end
 
   end

--- a/lib/compel/builder/any.rb
+++ b/lib/compel/builder/any.rb
@@ -8,16 +8,17 @@ module Compel
       end
 
       def if(lambda = nil, &block)
-        options[:if] = \
+        value = \
           if lambda && lambda.is_a?(Proc) && lambda.arity == 1
             lambda
           elsif block && block.arity == 0 && (block.call.is_a?(::Symbol) || block.call.is_a?(::String))
             block
+          else
+            fail
           end
 
-        fail if options[:if].nil?
+        build_option :if, value, options
 
-        self
         rescue
           raise Compel::TypeError, 'invalid proc for if'
       end

--- a/lib/compel/builder/any.rb
+++ b/lib/compel/builder/any.rb
@@ -7,6 +7,21 @@ module Compel
         super(Coercion::Any)
       end
 
+      def if(lambda = nil, &block)
+        options[:if] = \
+          if lambda && lambda.is_a?(Proc) && lambda.arity == 1
+            lambda
+          elsif block && block.arity == 0 && (block.call.is_a?(::Symbol) || block.call.is_a?(::String))
+            block
+          end
+
+        fail if options[:if].nil?
+
+        self
+        rescue
+          raise Compel::TypeError, 'invalid proc for if'
+      end
+
     end
 
   end

--- a/lib/compel/builder/common.rb
+++ b/lib/compel/builder/common.rb
@@ -27,6 +27,22 @@ module Compel
         build_option :max_length, Coercion.coerce!(value, Coercion::Integer), options
       end
 
+      def if(lambda = nil, options = {}, &block)
+        value = \
+          if lambda && lambda.is_a?(Proc) && lambda.arity == 1
+            lambda
+          elsif block && block.arity == 0 && (block.call.is_a?(::Symbol) || block.call.is_a?(::String))
+            block
+          else
+            fail
+          end
+
+        build_option :if, value, options
+
+        rescue
+          raise Compel::TypeError, 'invalid proc for if'
+      end
+
     end
 
   end

--- a/lib/compel/builder/common.rb
+++ b/lib/compel/builder/common.rb
@@ -28,19 +28,21 @@ module Compel
       end
 
       def if(lambda = nil, options = {}, &block)
-        value = \
-          if lambda && lambda.is_a?(Proc) && lambda.arity == 1
-            lambda
-          elsif block && block.arity == 0 && (block.call.is_a?(::Symbol) || block.call.is_a?(::String))
-            block
-          else
-            fail
-          end
-
-        build_option :if, value, options
+        build_option :if, coerce_if_proc(lambda || block), options
 
         rescue
           raise Compel::TypeError, 'invalid proc for if'
+      end
+
+      # this is lovely, refactor later
+      def coerce_if_proc(proc)
+        if proc && proc.is_a?(Proc) &&
+          (proc.arity == 1 || proc.arity == 0 &&
+            (proc.call.is_a?(::Symbol) || proc.call.is_a?(::String)))
+          proc
+        else
+          fail
+        end
       end
 
     end

--- a/lib/compel/validation/conditions/condition.rb
+++ b/lib/compel/validation/conditions/condition.rb
@@ -29,7 +29,13 @@ module Compel
       def validate_value_with_error_message
         error_message = validate_value
 
-        options[:message] || error_message
+        if error_message
+          error_message_with_value(options[:message] || error_message)
+        end
+      end
+
+      def error_message_with_value(message)
+        message.gsub(/\{\{value\}\}/, "#{value}")
       end
 
     end

--- a/lib/compel/validation/conditions/if.rb
+++ b/lib/compel/validation/conditions/if.rb
@@ -5,7 +5,7 @@ module Compel
 
       def validate_value
         unless valid?
-          "#{value} is invalid"
+          "'#{value}' is invalid"
         end
       end
 

--- a/lib/compel/validation/conditions/if.rb
+++ b/lib/compel/validation/conditions/if.rb
@@ -12,7 +12,11 @@ module Compel
       private
 
       def valid?
-        eval("#{option_value.call}(#{value})", option_value.binding)
+        if option_value.arity == 1
+          option_value.call(value)
+        else
+          eval("#{option_value.call}(#{value})", option_value.binding)
+        end
       end
 
     end

--- a/lib/compel/validation/conditions/if.rb
+++ b/lib/compel/validation/conditions/if.rb
@@ -1,0 +1,21 @@
+module Compel
+  module Validation
+
+    class If < Condition
+
+      def validate_value
+        unless valid?
+          "#{value} is invalid"
+        end
+      end
+
+      private
+
+      def valid?
+        eval("#{option_value.call}(#{value})", option_value.binding)
+      end
+
+    end
+
+  end
+end

--- a/lib/compel/validation/validation.rb
+++ b/lib/compel/validation/validation.rb
@@ -7,6 +7,7 @@ require 'compel/validation/conditions/format'
 require 'compel/validation/conditions/length'
 require 'compel/validation/conditions/min_length'
 require 'compel/validation/conditions/max_length'
+require 'compel/validation/conditions/if'
 
 require 'compel/validation/result'
 
@@ -24,6 +25,7 @@ module Compel
       length: Validation::Length,
       min_length: Validation::MinLength,
       max_length: Validation::MaxLength,
+      if: Validation::If,
     }
 
     def validate(value, type, options)

--- a/spec/compel/builder_spec.rb
+++ b/spec/compel/builder_spec.rb
@@ -216,7 +216,7 @@ describe Compel::Builder do
 
         subject(:builder) { Compel.string }
 
-        context 'in' do
+        context '#in' do
 
           it 'should set in value' do
             builder.in(['a', 'b'])
@@ -359,6 +359,45 @@ describe Compel::Builder do
             expect{ Compel.integer.min('ten') }.to \
               raise_error \
                 Compel::TypeError, 'Builder::Integer #min value must be a valid Integer'
+          end
+
+        end
+
+      end
+
+      context 'Any' do
+
+        context '#if' do
+
+          it 'should have a proc' do
+            _proc = ->(value) { value == 1 }
+
+            schema = Compel.any.if(_proc)
+
+            expect(schema.options[:if]).to eq _proc
+          end
+
+          it 'should have a block with string or symbol value' do
+            schema = Compel.any.if{:is_valid_one}
+            expect(schema.options[:if].call).to eq :is_valid_one
+
+            schema = Compel.any.if{'is_valid_one'}
+            expect(schema.options[:if].call).to eq 'is_valid_one'
+          end
+
+          it 'should raise_error for missing value' do
+            expect{ Compel.any.if('proc') }.to \
+              raise_error Compel::TypeError, 'invalid proc for if'
+          end
+
+          it 'should raise_error for invalid proc' do
+            expect{ Compel.any.if('proc') }.to \
+              raise_error Compel::TypeError, 'invalid proc for if'
+          end
+
+          it 'should raise_error for invalid proc arity' do
+            expect{ Compel.any.if(->(a, b) { a == b }) }.to \
+              raise_error Compel::TypeError, 'invalid proc for if'
           end
 
         end
@@ -520,6 +559,27 @@ describe Compel::Builder do
               result = schema.validate(OpenStruct)
 
               expect(result.valid?).to be true
+            end
+
+          end
+
+        end
+
+        context '#if' do
+
+          context 'valid' do
+
+            it 'should validate with custom method' do
+              def is_valid_one(value)
+                value == 1
+              end
+
+
+              schema = Compel.any.if{:is_valid_one}.required
+              schema.validate(@hash_value[:a])
+
+              schema = Compel.any.if(->(value) { value == 1 }).required
+              schema.validate(@hash_value[:a])
             end
 
           end

--- a/spec/compel/builder_spec.rb
+++ b/spec/compel/builder_spec.rb
@@ -375,15 +375,15 @@ describe Compel::Builder do
 
             schema = Compel.any.if(_proc)
 
-            expect(schema.options[:if]).to eq _proc
+            expect(schema.options[:if][:value]).to eq _proc
           end
 
           it 'should have a block with string or symbol value' do
             schema = Compel.any.if{:is_valid_one}
-            expect(schema.options[:if].call).to eq :is_valid_one
+            expect(schema.options[:if][:value].call).to eq :is_valid_one
 
             schema = Compel.any.if{'is_valid_one'}
-            expect(schema.options[:if].call).to eq 'is_valid_one'
+            expect(schema.options[:if][:value].call).to eq 'is_valid_one'
           end
 
           it 'should raise_error for missing value' do
@@ -630,17 +630,15 @@ describe Compel::Builder do
           context 'valid' do
 
             it 'should validate with custom method' do
-              value_to_validate = 1
-
               def is_valid_one(value)
                 value == 1
               end
 
               schema = Compel.any.if{:is_valid_one}.required
-              schema.validate(value_to_validate)
+              schema.validate(1)
 
               schema = Compel.any.if(->(value) { value == 1 }).required
-              schema.validate(value_to_validate)
+              schema.validate(1)
             end
 
           end

--- a/spec/compel/builder_spec.rb
+++ b/spec/compel/builder_spec.rb
@@ -721,6 +721,16 @@ describe Compel::Builder do
               expect(result.valid?).to eq(true)
             end
 
+            it 'should validate with custom method 1' do
+              def is_valid_one(value)
+                value == 1
+              end
+
+              result = Compel.any.if{|value| value == 1 }.validate(1)
+
+              expect(result.valid?).to eq(true)
+            end
+
             it 'should validate with lambda' do
               result = Compel.any.if(Proc.new {|value| value == 2 }).validate(2)
 

--- a/spec/compel/builder_spec.rb
+++ b/spec/compel/builder_spec.rb
@@ -387,7 +387,7 @@ describe Compel::Builder do
           end
 
           it 'should raise_error for missing value' do
-            expect{ Compel.any.if('proc') }.to \
+            expect{ Compel.any.if() }.to \
               raise_error Compel::TypeError, 'invalid proc for if'
           end
 

--- a/spec/compel/builder_spec.rb
+++ b/spec/compel/builder_spec.rb
@@ -569,7 +569,7 @@ describe Compel::Builder do
 
           context 'valid' do
 
-            it 'should validate with custom method' do
+            xit 'should validate with custom method' do
               def is_valid_one(value)
                 value == 1
               end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'simplecov'
 require 'codeclimate-test-reporter'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'pry'
 require 'simplecov'
 require 'codeclimate-test-reporter'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'simplecov'
 require 'codeclimate-test-reporter'
 
 SimpleCov.start do
-  formatter SimpleCov::Formatter::MultiFormatter[
+  formatter SimpleCov::Formatter::MultiFormatter.new [
     SimpleCov::Formatter::HTMLFormatter,
     CodeClimate::TestReporter::Formatter
   ]


### PR DESCRIPTION
- adding **`#if`** to **`Any`** builder
  
  **\- as a proc:**
  
  ``` ruby
  Compel.integer.if(->(value){ value > 2 }).validate(1)
  ```
  
  **\- as a block:**
  
  ``` ruby
  Compel.string.if{|value| value.length > 2 }.validate("abc")
  ```
  
  **\- as a block with a `string` or a `symbol` to link with a method:**
  
  ``` ruby
  def is_valid_one(value)
    value == 1
  end
  
  Compel.any.if{:is_valid_one}.validate(1)
  # or with a string: if{'is_valid_one'}
  ```
